### PR TITLE
Don't compile tests if `MVN_SKIP_TESTS` is set

### DIFF
--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -31,7 +31,8 @@ echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 
 echo "---> Building application from source..."
-mvn ${MVN_GOALS:-clean package} -DskipTests=${MVN_SKIP_TESTS:-true} ${MVN_OPTS}
+mvn ${MVN_GOALS:-clean package} -DskipTests=${MVN_SKIP_TESTS:-true} \
+  -Dmaven.skip.tests=${MVN_SKIP_TESTS:-true} ${MVN_OPTS}
 
 echo "---> Copying built application to app-root..."
 # TODO this may fail if there are more than one jar generated


### PR DESCRIPTION
From the [maven docs on skipping tests][1]:

* `-DskipTests` will compile the tests but not run them
* `-Dmaven.test.skip=true` will not even compile the tests.

This can be relevant with Spring apps that have tests that use the `@SpringBootTest` annotation, which may start the spring application during `mvn package` jobs (which in turn may block the build).

[1]: http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html