### PR TITLE
Update base image to maintained centos s2i base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 MAINTAINER Tobias Brunner <tobias.brunner@vshn.ch>
 


### PR DESCRIPTION
the openshift/base-centos7 image is unmaintained. This PR updates the base image of the maven s2i image.

While testing the build it ran into a problem. The defined Maven Version `3.5.2` is not available in the current repo:
http://www-eu.apache.org/dist/maven/maven-3/

We could either update the Maven Version or switch to https://archive.apache.org/dist/maven/maven-3 @tobru what do you recommend?